### PR TITLE
Broadcast image/name changes to the websocket for updating

### DIFF
--- a/gui/src/resources/message_row.xml
+++ b/gui/src/resources/message_row.xml
@@ -30,6 +30,9 @@
             <property name="orientation">vertical</property>
             <child>
               <object class="GtkLabel" id="sent_by">
+                <property name="ellipsize">end</property>
+                <property name="lines">1</property>
+                <property name="max-width-chars">25</property>
                 <property name="selectable">true</property>
                 <property name="margin-start">6</property>
                 <property name="margin-end">6</property>

--- a/gui/src/resources/user_profile.xml
+++ b/gui/src/resources/user_profile.xml
@@ -29,6 +29,7 @@
                     <property name="margin-start">20</property>
                     <property name="margin-end">20</property>
                     <property name="spacing">20</property>
+                    <!-- Top avatar-->
                     <child>
                       <object class="AdwAvatar" id="profile_avatar">
                         <property name="show-initials">true</property>
@@ -42,6 +43,7 @@
                           <class name="boxed-list" />
                         </style>
                         <child>
+                          <!-- The name row-->
                           <object class="AdwActionRow" id="name_row">
                             <property name="title">Name</property>
                             <child>
@@ -55,6 +57,7 @@
                           </object>
                         </child>
                         <child>
+                          <!-- The ID row-->
                           <object class="AdwActionRow" id="id_row">
                             <property name="title">User ID</property>
                             <child>
@@ -76,6 +79,7 @@
                           </object>
                         </child>
                         <child>
+                          <!-- The image link row-->
                           <object class="AdwActionRow" id="image_link_row">
                             <property name="title">Image Link</property>
                             <property name="subtitle-lines">1</property>
@@ -114,6 +118,7 @@
           </object>
         </child>
         <child>
+          <!-- The revealer that shows up upon actions like copy or reload iamge-->
           <object class="GtkRevealer" id="copy_revealer">
             <property name="transition-duration">800</property>
             <property name="visible">false</property>
@@ -123,6 +128,9 @@
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkLabel" id="copy_info">
+                    <property name="ellipsize">end</property>
+                    <property name="lines">1</property>
+                    <property name="max-width-chars">25</property>
                   </object>
                 </child>
               </object>

--- a/gui/src/user/user_profile.rs
+++ b/gui/src/user/user_profile.rs
@@ -84,22 +84,23 @@ wrapper! {
 impl UserProfile {
     pub fn new(user_data: UserObject, window: &window::Window) -> Self {
         let obj: UserProfile = Object::builder().build();
+        obj.imp().user_data.set(user_data).unwrap();
         obj.set_transient_for(Some(window));
         obj.set_modal(true);
         obj.set_visible(true);
-        obj.bind(&user_data);
+        obj.bind();
         obj.connect_button_signals();
-        obj.imp().user_data.set(user_data).unwrap();
         obj
     }
 
-    fn bind(&self, user_data: &UserObject) {
+    fn bind(&self) {
         let mut bindings = self.imp().bindings.borrow_mut();
         let profile_avatar = self.imp().profile_avatar.get();
         let name_row = self.imp().name_row.get();
         let id_row = self.imp().id_row.get();
         let image_link_row = self.imp().image_link_row.get();
         let id_warning = self.imp().id_warning.get();
+        let user_data = self.imp().user_data.get().unwrap();
 
         let avatar_text_binding = user_data
             .bind_property("name", &profile_avatar, "text")

--- a/gui/src/user/user_prompt.rs
+++ b/gui/src/user/user_prompt.rs
@@ -125,6 +125,7 @@ impl UserPrompt {
                 info!("Updating name to: {}", entry_data);
                 window.start_revealer(&format!("Updating name to: {}", entry_data));
                 user_data.set_new_name(entry_data.to_string());
+                user_data.user_ws().name_updated(&entry_data);
                 dialog.destroy();
             }),
         );
@@ -149,6 +150,7 @@ impl UserPrompt {
                 info!("Updating image link to: {}", entry_data);
                 window.start_revealer("Starting updating image...");
                 user_data.set_new_image_link(entry_data.to_string());
+                user_data.user_ws().image_link_updated(&entry_data);
                 dialog.destroy();
             }),
         );

--- a/gui/src/window.rs
+++ b/gui/src/window.rs
@@ -180,7 +180,6 @@ impl Window {
         info!("Setting chatting with {}", user.name());
         self.set_title(Some(&format!("Chirp - {}", user.name())));
         let message_list = user.messages();
-        info!("Binding model");
         self.imp().message_list.bind_model(
             Some(&message_list),
             clone!(@weak self as window => @default-panic, move |obj| {
@@ -240,9 +239,9 @@ impl Window {
 
         info!("Sending new text message: {}", content);
 
-        if let Some(conn) = self.get_chatting_from().user_ws().ws_conn() {
-            conn.send_text(&content);
-        }
+        self.get_chatting_from()
+            .user_ws()
+            .send_text_message(&content);
 
         buffer.set_text("");
 
@@ -321,7 +320,8 @@ impl Window {
                     let user_row = UserRow::new(user);
                     window.get_user_list().append(&user_row);
                 }
-                _ => window.receive_message(&response, user_object),
+                "/message" => window.receive_message(&response_data[1], user_object),
+                _ => {}
             }
             ControlFlow::Continue
         }));

--- a/gui/src/ws/ws_data.rs
+++ b/gui/src/ws/ws_data.rs
@@ -104,6 +104,13 @@ impl WSObject {
         );
     }
 
+    pub fn send_text_message(&self, message: &str) {
+        if let Some(conn) = self.ws_conn() {
+            info!("Sending message to ws: {message}");
+            conn.send_text(&format!("/message {}", message));
+        }
+    }
+
     pub fn create_new_user(&self, user_data: String) {
         if let Some(conn) = self.ws_conn() {
             info!("Connecting to WS to create a new user");
@@ -132,6 +139,20 @@ impl WSObject {
         if let Some(conn) = self.ws_conn() {
             info!("Sending info to update ids");
             conn.send_text(&format!("/update-ids {} {}", id, client_id))
+        }
+    }
+
+    pub fn image_link_updated(&self, link: &str) {
+        if let Some(conn) = self.ws_conn() {
+            info!("Sending updated image link: {link}");
+            conn.send_text(&format!("/image-updated {}", link))
+        }
+    }
+
+    pub fn name_updated(&self, name: &str) {
+        if let Some(conn) = self.ws_conn() {
+            info!("Sending updated name: {name}");
+            conn.send_text(&format!("/name-updated {}", name))
         }
     }
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -16,7 +16,6 @@ async fn chat_route(
             id: 0,
             user_id: 0,
             hb: Instant::now(),
-            name: None,
             addr: srv.get_ref().clone(),
         },
         &req,


### PR DESCRIPTION
Resolves #10 

* New ws communication type and use a separate / type for normal messages
* Ellipsize longer name on notification popup and on message row
* All changes on the profile section are immediately broadcasted to the WS and to the required clients