### PR TITLE
Handling WS requests in queue

### DIFF
--- a/gui/src/user/mod.rs
+++ b/gui/src/user/mod.rs
@@ -3,7 +3,7 @@ pub mod user_profile;
 pub mod user_prompt;
 pub mod user_row;
 
-pub use user_data::{FullUserData, UserObject};
+pub use user_data::{FullUserData, MessageData, RequestType, UserObject};
 pub use user_profile::UserProfile;
 pub use user_prompt::UserPrompt;
 pub use user_row::UserRow;

--- a/gui/src/user/mod.rs
+++ b/gui/src/user/mod.rs
@@ -3,7 +3,7 @@ pub mod user_profile;
 pub mod user_prompt;
 pub mod user_row;
 
-pub use user_data::{FullUserData, MessageData, RequestType, UserObject};
+pub use user_data::{FullUserData, RequestType, SendMessageData, UserObject};
 pub use user_profile::UserProfile;
 pub use user_prompt::UserPrompt;
 pub use user_row::UserRow;

--- a/gui/src/user/user_data.rs
+++ b/gui/src/user/user_data.rs
@@ -69,7 +69,6 @@ impl UserObject {
         image_link: Option<String>,
         color_to_ignore: Option<&str>,
         user_id: Option<u64>,
-        owner_id: u64,
     ) -> Self {
         let ws = WSObject::new();
         let messages = ListStore::new::<MessageObject>();
@@ -83,7 +82,6 @@ impl UserObject {
             .property("image-link", image_link.clone())
             .property("messages", messages)
             .property("name-color", random_color)
-            .property("owner-id", owner_id)
             .build();
 
         obj.check_image_link();
@@ -248,7 +246,6 @@ impl UserObject {
 
     fn start_listening(&self, sender: Sender<String>) {
         let user_ws = self.user_ws();
-
         if !user_ws.reconnecting() {
             if self.user_id() == 0 {
                 self.add_to_queue(RequestType::CreateNewUser);
@@ -269,10 +266,7 @@ impl UserObject {
                         "/update-user-id" => {
                             let id: u64 = splitted_data[1].parse().unwrap();
                             user_object.set_user_id(id);
-
-                            if user_object.owner_id() == 0 {
-                                user_object.set_owner_id(id);
-                            }
+                            sender.send(text).unwrap()
                         }
                         "/update-session-id" => {
                             let id: u64 = splitted_data[1].parse().unwrap();

--- a/gui/src/user/user_data.rs
+++ b/gui/src/user/user_data.rs
@@ -5,11 +5,11 @@ mod imp {
     use gio::ListStore;
     use glib::{derived_properties, object_subclass, Properties};
     use gtk::{gdk, glib};
-    use std::cell::{OnceCell, RefCell};
+    use std::cell::{Cell, OnceCell, RefCell};
 
     use crate::ws::WSObject;
 
-    use super::UserData;
+    use super::{RequestType, UserData};
 
     #[derive(Properties, Default)]
     #[properties(wrapper_type = super::UserObject)]
@@ -25,6 +25,11 @@ mod imp {
         pub messages: OnceCell<ListStore>,
         #[property(get, set)]
         pub user_ws: OnceCell<WSObject>,
+        pub request_queue: RefCell<Vec<RequestType>>,
+        #[property(get, set)]
+        pub request_processing: Cell<bool>,
+        #[property(get, set)]
+        pub owner_id: Cell<u64>,
     }
 
     #[object_subclass]
@@ -40,6 +45,7 @@ mod imp {
 use adw::prelude::*;
 use gdk::{gdk_pixbuf, Paintable, Texture};
 use gdk_pixbuf::InterpType;
+use gio::subclass::prelude::ObjectSubclassIsExt;
 use gio::{spawn_blocking, ListStore};
 use glib::{
     clone, closure_local, Bytes, ControlFlow, MainContext, Object, Priority, Receiver, Sender,
@@ -48,7 +54,9 @@ use gtk::{gdk, glib, Image};
 use serde::{Deserialize, Serialize};
 use tracing::info;
 
+use crate::message::MessageObject;
 use crate::utils::{generate_random_avatar_link, get_avatar, get_random_color};
+use crate::window::Window;
 use crate::ws::WSObject;
 
 glib::wrapper! {
@@ -59,11 +67,12 @@ impl UserObject {
     pub fn new(
         name: &str,
         image_link: Option<String>,
-        messages: ListStore,
         color_to_ignore: Option<&str>,
-        user_ws: WSObject,
         user_id: Option<u64>,
+        owner_id: u64,
     ) -> Self {
+        let ws = WSObject::new();
+        let messages = ListStore::new::<MessageObject>();
         let random_color = get_random_color(color_to_ignore);
 
         let id = if let Some(id) = user_id { id } else { 0 };
@@ -74,10 +83,28 @@ impl UserObject {
             .property("image-link", image_link.clone())
             .property("messages", messages)
             .property("name-color", random_color)
+            .property("owner-id", owner_id)
             .build();
 
         obj.check_image_link();
-        obj.set_user_ws(user_ws);
+        obj.set_user_ws(ws);
+        let user_object = obj.clone();
+        obj.user_ws().connect_closure(
+            "ws-reconnect",
+            false,
+            closure_local!(move |_from: WSObject, _success: bool| {
+                info!("Reconnected");
+                let old_queue = user_object.imp().request_queue.borrow().clone();
+                user_object.imp().request_queue.replace(Vec::new());
+                user_object
+                    .add_to_queue(RequestType::ReconnectUser)
+                    .add_to_queue(RequestType::UpdateIDs);
+
+                for old in old_queue {
+                    user_object.add_to_queue(old);
+                }
+            }),
+        );
         obj
     }
 
@@ -122,6 +149,63 @@ impl UserObject {
         );
     }
 
+    pub fn add_to_queue(&self, request_type: RequestType) -> &Self {
+        {
+            let mut queue = self.imp().request_queue.borrow_mut();
+            queue.push(request_type);
+        }
+
+        if !self.request_processing() {
+            self.process_queue();
+        };
+        self
+    }
+
+    fn process_queue(&self) {
+        self.set_request_processing(true);
+
+        let user_ws = self.user_ws();
+
+        let mut queue_list = self.imp().request_queue.borrow_mut();
+
+        let mut highest_index = 0;
+        for task in queue_list.iter() {
+            if user_ws.ws_conn().is_some() {
+                info!("starting processing {task:?}");
+                match task {
+                    RequestType::ReconnectUser => {
+                        let owner_id = self.owner_id();
+                        let user_data = self.convert_to_json();
+                        user_ws.reconnect_user(owner_id, user_data);
+                    }
+                    RequestType::UpdateIDs => user_ws.update_ids(self.user_id(), self.owner_id()),
+                    RequestType::CreateNewUser => {
+                        let user_data = self.convert_to_json();
+                        user_ws.create_new_user(user_data);
+                    }
+                    RequestType::SendMessage(msg) => {
+                        user_ws.send_text_message(&msg.convert_to_json())
+                    }
+                    RequestType::ImageUpdated(link) => user_ws.image_link_updated(link),
+                    RequestType::NameUpdated(name) => user_ws.name_updated(name),
+                    RequestType::GetUserData(id) => user_ws.get_user_data(id),
+                    RequestType::UpdateChattingWith(id) => user_ws.update_chatting_with(id),
+                }
+                highest_index += 1;
+            } else {
+                info!("Connection lost. Stopping processing request");
+                break;
+            }
+        }
+
+        for _x in 0..highest_index {
+            info!("Removing {:?}", queue_list[0]);
+            queue_list.remove(0);
+        }
+
+        self.set_request_processing(false);
+    }
+
     pub fn set_new_name(&self, name: String) {
         self.set_name(name);
     }
@@ -134,35 +218,34 @@ impl UserObject {
     pub fn set_random_image(&self) {
         let new_link = generate_random_avatar_link();
         info!("Generated random image link: {}", new_link);
-        self.user_ws().image_link_updated(&new_link);
+        self.add_to_queue(RequestType::ImageUpdated(new_link.to_owned()));
         self.set_new_image_link(new_link);
     }
 
-    pub fn handle_ws(&self, owner_id: u64) -> Receiver<String> {
-        let (sender, receiver) = MainContext::channel(Priority::DEFAULT);
+    pub fn handle_ws(&self, window: Window) {
         let user_object = self.clone();
+
         let user_ws = self.user_ws();
         user_ws.connect_closure(
             "ws-success",
             false,
-            closure_local!(move |_from: WSObject, success: bool| {
-                if success {
-                    user_object.start_listening(sender.clone(), owner_id);
-                }
+            closure_local!(move |_from: WSObject, _success: bool| {
+                let (sender, receiver) = MainContext::channel(Priority::DEFAULT);
+                user_object.start_listening(sender.clone());
+                window.handle_ws_message(&user_object, receiver);
             }),
         );
-
-        receiver
     }
 
-    fn start_listening(&self, sender: Sender<String>, owner_id: u64) {
+    fn start_listening(&self, sender: Sender<String>) {
         let user_ws = self.user_ws();
 
-        if self.user_id() == 0 {
-            let user_data = self.convert_to_json();
-            user_ws.create_new_user(user_data);
-        } else {
-            user_ws.update_ids(self.user_id(), owner_id)
+        if !user_ws.reconnecting() {
+            if self.user_id() == 0 {
+                self.add_to_queue(RequestType::CreateNewUser);
+            } else {
+                self.add_to_queue(RequestType::UpdateIDs);
+            }
         }
 
         let id = user_ws.ws_conn().unwrap().connect_message(
@@ -177,6 +260,10 @@ impl UserObject {
                         "/update-user-id" => {
                             let id: u64 = splitted_data[1].parse().unwrap();
                             user_object.set_user_id(id);
+
+                            if user_object.owner_id() == 0 {
+                                user_object.set_owner_id(id);
+                            }
                         }
                         "/update-session-id" => {
                             let id: u64 = splitted_data[1].parse().unwrap();
@@ -223,4 +310,36 @@ pub struct FullUserData {
     pub id: u64,
     pub name: String,
     pub image_link: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub enum RequestType {
+    CreateNewUser,
+    NameUpdated(String),
+    ImageUpdated(String),
+    ReconnectUser,
+    UpdateIDs,
+    SendMessage(MessageData),
+    UpdateChattingWith(u64),
+    GetUserData(u64),
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct MessageData {
+    pub from_user: u64,
+    pub to_user: u64,
+    pub msg: String,
+}
+
+impl MessageData {
+    pub fn new(from_user: u64, to_user: u64, msg: String) -> Self {
+        MessageData {
+            msg,
+            from_user,
+            to_user,
+        }
+    }
+    fn convert_to_json(&self) -> String {
+        serde_json::to_string(self).unwrap()
+    }
 }

--- a/gui/src/user/user_prompt.rs
+++ b/gui/src/user/user_prompt.rs
@@ -44,7 +44,7 @@ use gtk::{
 };
 use tracing::info;
 
-use crate::user::{UserObject, UserProfile};
+use crate::user::{RequestType, UserObject, UserProfile};
 use crate::window;
 
 wrapper! {
@@ -99,8 +99,8 @@ impl UserPrompt {
                 // TODO parse number properly
                 let entry_data = entry.text();
                 info!("Entry data: {}", entry_data);
-                let conn = window.get_chatting_from().user_ws();
-                conn.get_user_data(entry_data.parse().unwrap());
+                window.get_chatting_from().add_to_queue(RequestType::GetUserData(entry_data.parse().unwrap()));
+
                 dialog.destroy();
             }),
         );
@@ -125,7 +125,7 @@ impl UserPrompt {
                 info!("Updating name to: {}", entry_data);
                 window.start_revealer(&format!("Updating name to: {}", entry_data));
                 user_data.set_new_name(entry_data.to_string());
-                user_data.user_ws().name_updated(&entry_data);
+                user_data.add_to_queue(RequestType::NameUpdated(entry_data.to_string()));
                 dialog.destroy();
             }),
         );

--- a/gui/src/utils.rs
+++ b/gui/src/utils.rs
@@ -27,7 +27,8 @@ fn generate_random_number(length: usize) -> String {
 
 pub fn generate_robohash_link() -> String {
     let random_num = generate_random_number(5);
-    format!("https://robohash.org/{random_num}.svg")
+    let set_num = rand::thread_rng().gen_range(1..5);
+    format!("https://robohash.org/{random_num}.svg?set=set{set_num}")
 }
 
 pub fn generate_dicebear_link() -> String {
@@ -36,7 +37,6 @@ pub fn generate_dicebear_link() -> String {
         "bottts",
         "lorelei",
         "adventurer",
-        "identicon",
         "open-peeps",
     ];
 
@@ -48,6 +48,7 @@ pub fn generate_dicebear_link() -> String {
 }
 
 // TODO: Perhaps we can add other types of image here
+// NOTE Identicon
 pub fn generate_random_avatar_link() -> String {
     let choices = ["dicebear", "robohash"];
 

--- a/gui/src/utils.rs
+++ b/gui/src/utils.rs
@@ -32,13 +32,23 @@ pub fn generate_robohash_link() -> String {
 }
 
 pub fn generate_dicebear_link() -> String {
-    let choices = ["micah", "bottts", "lorelei", "adventurer", "open-peeps"];
+    let choices = [
+        "micah",
+        "bottts",
+        "lorelei",
+        "adventurer",
+        "open-peeps",
+        "bottts-neutral",
+        "notionists",
+        "rings",
+        "shapes",
+    ];
 
     let random_index = rand::thread_rng().gen_range(0..choices.len());
     let selected_choice = choices[random_index];
 
     let random_num = generate_random_number(5);
-    format!("https://api.dicebear.com/6.x/{selected_choice}/svg?seed={random_num}")
+    format!("https://api.dicebear.com/7.x/{selected_choice}/svg?seed={random_num}")
 }
 
 // TODO: Perhaps we can add other types of image here

--- a/gui/src/utils.rs
+++ b/gui/src/utils.rs
@@ -32,13 +32,7 @@ pub fn generate_robohash_link() -> String {
 }
 
 pub fn generate_dicebear_link() -> String {
-    let choices = [
-        "micah",
-        "bottts",
-        "lorelei",
-        "adventurer",
-        "open-peeps",
-    ];
+    let choices = ["micah", "bottts", "lorelei", "adventurer", "open-peeps"];
 
     let random_index = rand::thread_rng().gen_range(0..choices.len());
     let selected_choice = choices[random_index];

--- a/gui/src/ws/ws_data.rs
+++ b/gui/src/ws/ws_data.rs
@@ -1,22 +1,26 @@
 mod imp {
     use adw::prelude::*;
     use adw::subclass::prelude::*;
+    use gio::glib::Sender;
     use glib::once_cell::sync::Lazy;
     use glib::subclass::Signal;
     use glib::{derived_properties, object_subclass, Properties, SignalHandlerId};
     use gtk::glib;
     use soup::WebsocketConnection;
-    use std::cell::{OnceCell, RefCell};
-    use std::rc::Rc;
+    use std::cell::{Cell, OnceCell, RefCell};
 
     #[derive(Properties, Default)]
     #[properties(wrapper_type = super::WSObject)]
     pub struct WSObject {
         #[property(get, set)]
-        pub ws_conn: Rc<RefCell<Option<WebsocketConnection>>>,
+        pub ws_conn: RefCell<Option<WebsocketConnection>>,
         #[property(get, set)]
-        pub ws_id: OnceCell<u64>,
+        pub ws_id: Cell<u64>,
         pub ws_signal_id: RefCell<Option<SignalHandlerId>>,
+        pub ws_sender: OnceCell<Sender<Option<WebsocketConnection>>>,
+        pub notifier: OnceCell<Sender<bool>>,
+        #[property(get, set)]
+        pub reconnecting: Cell<bool>,
     }
 
     #[object_subclass]
@@ -29,9 +33,14 @@ mod imp {
     impl ObjectImpl for WSObject {
         fn signals() -> &'static [Signal] {
             static SIGNALS: Lazy<Vec<Signal>> = Lazy::new(|| {
-                vec![Signal::builder("ws-success")
-                    .param_types([bool::static_type()])
-                    .build()]
+                vec![
+                    Signal::builder("ws-success")
+                        .param_types([bool::static_type()])
+                        .build(),
+                    Signal::builder("ws-reconnect")
+                        .param_types([bool::static_type()])
+                        .build(),
+                ]
             });
             SIGNALS.as_ref()
         }
@@ -40,9 +49,12 @@ mod imp {
 
 use adw::subclass::prelude::*;
 use gio::Cancellable;
-use glib::{clone, wrapper, ControlFlow, MainContext, Object, Priority, Receiver, SignalHandlerId};
+use glib::{
+    clone, timeout_add_seconds_local_once, wrapper, ControlFlow, MainContext, Object, Priority,
+    SignalHandlerId,
+};
 use gtk::{glib, prelude::*};
-use soup::{prelude::*, Message, Session, WebsocketConnection};
+use soup::{prelude::*, Message, Session};
 use tracing::{error, info};
 
 wrapper! {
@@ -56,14 +68,17 @@ impl WSObject {
         obj
     }
 
-    pub fn get_ws_receiver(&self) -> Receiver<Option<WebsocketConnection>> {
+    pub fn connect_to_ws(&self) {
         let session = Session::new();
+        let sender = self.imp().ws_sender.get().unwrap().clone();
 
         let websocket_url = "ws://127.0.0.1:8080/ws/";
 
-        let (sender, receiver) = MainContext::channel(Priority::DEFAULT);
         let message = Message::new("GET", websocket_url).unwrap();
         let cancel = Cancellable::new();
+
+        let is_reconnecting = self.reconnecting();
+        let notifier = self.imp().notifier.get().unwrap().clone();
 
         info!("Starting websocket connection with {}", websocket_url);
         session.websocket_connect_async(
@@ -75,6 +90,9 @@ impl WSObject {
             move |result| match result {
                 Ok(connection) => {
                     sender.send(Some(connection)).unwrap();
+                    if is_reconnecting {
+                        notifier.send(true).unwrap()
+                    };
                 }
                 Err(error) => {
                     sender.send(None).unwrap();
@@ -82,11 +100,20 @@ impl WSObject {
                 }
             },
         );
-        receiver
     }
 
     fn set_ws(&self) {
-        let receiver = self.get_ws_receiver();
+        let (sender, receiver) = MainContext::channel(Priority::DEFAULT);
+
+        self.imp().ws_sender.set(sender).unwrap();
+
+        let (notifier_send, notifier_receive) = MainContext::channel(Priority::DEFAULT);
+
+        self.imp().notifier.set(notifier_send).unwrap();
+
+        self.set_reconnecting(false);
+
+        self.connect_to_ws();
 
         receiver.attach(
             None,
@@ -95,65 +122,96 @@ impl WSObject {
                     ws_object.set_ws_conn(conn.unwrap());
                     info!("WebSocket connection success");
                     ws_object.emit_by_name::<()>("ws-success", &[&true]);
+                    ws_object.start_pinging();
                 } else {
-                    error!("WebSocket connection failed");
-                    ws_object.emit_by_name::<()>("ws-success", &[&false]);
+                    error!("WebSocket connection failed. Starting again");
+                    timeout_add_seconds_local_once(10, move || {
+                        ws_object.connect_to_ws();
+                    });
                 }
+                ControlFlow::Continue
+            }),
+        );
+
+        notifier_receive.attach(
+            None,
+            clone!(@weak self as ws => @default-return ControlFlow::Break, move |_| {
+                ws.emit_by_name::<()>("ws-reconnect", &[&true]);
+                info!("Emitted");
                 ControlFlow::Continue
             }),
         );
     }
 
     pub fn send_text_message(&self, message: &str) {
-        if let Some(conn) = self.ws_conn() {
-            info!("Sending message to ws: {message}");
-            conn.send_text(&format!("/message {}", message));
-        }
+        info!("Sending message to ws: {message}");
+        self.ws_conn()
+            .unwrap()
+            .send_text(&format!("/message {}", message));
     }
 
     pub fn create_new_user(&self, user_data: String) {
-        if let Some(conn) = self.ws_conn() {
-            info!("Connecting to WS to create a new user");
-            conn.send_text(&format!("/create-new-user {}", user_data));
-        }
+        info!("Connecting to WS to create a new user");
+        self.ws_conn()
+            .unwrap()
+            .send_text(&format!("/create-new-user {}", user_data));
     }
 
-    pub fn update_chatting_with(&self, id: u64) {
-        if let Some(conn) = self.ws_conn() {
-            info!("Sending request for updating chatting with id to {}", id);
-            conn.send_text(&format!("/update-chatting-with {}", id))
-        }
+    pub fn update_chatting_with(&self, id: &u64) {
+        info!("Sending request for updating chatting with id to {}", id);
+        self.ws_conn()
+            .unwrap()
+            .send_text(&format!("/update-chatting-with {}", id))
     }
 
-    pub fn get_user_data(&self, id: u64) {
-        if let Some(conn) = self.ws_conn() {
-            info!(
-                "Sending request for getting UserObject Data with id: {}",
-                id
-            );
-            conn.send_text(&format!("/get-user-data {}", id))
-        }
+    pub fn get_user_data(&self, id: &u64) {
+        info!(
+            "Sending request for getting UserObject Data with id: {}",
+            id
+        );
+        self.ws_conn()
+            .unwrap()
+            .send_text(&format!("/get-user-data {}", id))
     }
 
     pub fn update_ids(&self, id: u64, client_id: u64) {
-        if let Some(conn) = self.ws_conn() {
-            info!("Sending info to update ids");
-            conn.send_text(&format!("/update-ids {} {}", id, client_id))
-        }
+        info!("Sending info to update ids");
+        self.ws_conn()
+            .unwrap()
+            .send_text(&format!("/update-ids {} {}", id, client_id))
     }
 
     pub fn image_link_updated(&self, link: &str) {
-        if let Some(conn) = self.ws_conn() {
-            info!("Sending updated image link: {link}");
-            conn.send_text(&format!("/image-updated {}", link))
-        }
+        info!("Sending updated image link: {link}");
+        self.ws_conn()
+            .unwrap()
+            .send_text(&format!("/image-updated {}", link))
     }
 
     pub fn name_updated(&self, name: &str) {
-        if let Some(conn) = self.ws_conn() {
-            info!("Sending updated name: {name}");
-            conn.send_text(&format!("/name-updated {}", name))
-        }
+        info!("Sending updated name: {name}");
+        self.ws_conn()
+            .unwrap()
+            .send_text(&format!("/name-updated {}", name))
+    }
+
+    pub fn start_pinging(&self) {
+        let conn = self.ws_conn().unwrap();
+        conn.set_keepalive_interval(5);
+
+        conn.connect_closed(clone!(@weak self as ws => move |_| {
+            info!("connection closed. Starting again");
+            ws.imp().ws_conn.replace(None);
+            ws.set_reconnecting(true);
+            ws.connect_to_ws();
+        }));
+    }
+
+    pub fn reconnect_user(&self, owner_id: u64, user_data: String) {
+        info!("Updating WS to reconnect old owner: {}", owner_id);
+        self.ws_conn()
+            .unwrap()
+            .send_text(&format!("/reconnect-user {} {user_data}", owner_id))
     }
 
     pub fn set_signal_id(&self, id: SignalHandlerId) {

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -30,7 +30,7 @@ pub struct ClientMessage {
 
 impl ClientMessage {
     pub fn new(data: &str) -> Self {
-        serde_json::from_str(&data).unwrap()
+        serde_json::from_str(data).unwrap()
     }
 }
 

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -141,12 +141,14 @@ impl ChatServer {
         }
     }
 
+    /// Sends the WS Connection ID to the client
     fn send_session_id(&self, id: usize) {
         if let Some((_, _, receiver_ws)) = self.sessions.get(&id) {
             receiver_ws.do_send(Message(format!("/update-session-id {}", id)))
         };
     }
 
+    /// Creates a new user and allocates necessary data to communicate with it
     fn create_new_user(&mut self, ws_id: usize, other_data: String) {
         let user_id = self.rng.gen::<usize>();
         info!(
@@ -170,6 +172,7 @@ impl ChatServer {
             .push(ws_data);
     }
 
+    /// Allocates necessary data to communicate with a previously deleted user
     fn reconnect_user(&mut self, ws_id: usize, user_id: usize, other_data: String) {
         info!("Reconnecting user");
         let user_data = UserData::new(other_data).update_id(user_id);
@@ -188,6 +191,7 @@ impl ChatServer {
             .push(ws_data);
     }
 
+    /// Sends user profile data to the client
     fn send_user_data(&mut self, ws_id: usize, id: usize) {
         info!("Sending user data of with id {}", id);
         if let Some(data) = self.user_data.get(&id) {
@@ -209,6 +213,7 @@ impl ChatServer {
         };
     }
 
+    /// Used to keep track of active user ws connections
     fn update_ids(&mut self, ws_id: usize, user_id: usize, client_id: usize) {
         if let Some(entry) = self.sessions.get_mut(&ws_id) {
             let (session_user_id, _, _) = entry;
@@ -224,6 +229,7 @@ impl ChatServer {
         }
     }
 
+    /// Updates user name
     fn update_user_name(&mut self, ws_id: usize, new_name: String) {
         let user_id = &self.sessions[&ws_id].0;
 
@@ -242,6 +248,7 @@ impl ChatServer {
         }
     }
 
+    /// Updates image link of a user
     fn update_user_image_link(&mut self, ws_id: usize, new_link: String) {
         let user_id = &self.sessions[&ws_id].0;
 

--- a/server/src/session.rs
+++ b/server/src/session.rs
@@ -101,6 +101,11 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for WsChatSession {
                             user_data: v[1].to_string(),
                             comm_type: CommunicationType::CreateNewUser,
                         }),
+                        "/reconnect-user" => self.addr.do_send(CommunicateUser {
+                            ws_id: self.id,
+                            user_data: v[1].to_string(),
+                            comm_type: CommunicationType::ReconnectUser,
+                        }),
                         "/update-chatting-with" => self.addr.do_send(ChattingWithUpdate {
                             chatting_from: self.id,
                             chatting_with: v[1].parse().unwrap(),
@@ -115,10 +120,10 @@ impl StreamHandler<Result<ws::Message, ws::ProtocolError>> for WsChatSession {
                             user_data: v[1].to_string(),
                             comm_type: CommunicationType::UpdateUserIDs,
                         }),
-                        "/message" => self.addr.do_send(ClientMessage {
-                            id: self.id,
-                            msg: v[1].to_string(),
-                        }),
+                        "/message" => {
+                            let client_message = ClientMessage::new(v[1]);
+                            self.addr.do_send(client_message)
+                        }
                         "/name-updated" => self.addr.do_send(CommunicateUser {
                             ws_id: self.id,
                             user_data: v[1].to_string(),


### PR DESCRIPTION
Resolves #11 

* The gui can now wait and keep trying to connect to the WS
* A single vector is maintained to handle all WS process requests in FIFO order
* Can communicate events sent without WS after the connection is established to some degree. Further accurate action would require a database 
* Updated random image api